### PR TITLE
add support for build with sytem library

### DIFF
--- a/snappy.c
+++ b/snappy.c
@@ -9,7 +9,7 @@
 #include "php_snappy.h"
 
 /* snappy */
-#include "snappy/snappy-c.h"
+#include <snappy-c.h>
 
 static ZEND_FUNCTION(snappy_compress);
 static ZEND_FUNCTION(snappy_uncompress);
@@ -33,7 +33,11 @@ PHP_MINFO_FUNCTION(snappy)
     php_info_print_table_start();
     php_info_print_table_row(2, "Snappy support", "enabled");
     php_info_print_table_row(2, "Extension Version", SNAPPY_EXT_VERSION);
+#ifdef HAVE_LIBSNAPPY
+    php_info_print_table_row(2, "Snappy Version", "system library");
+#else
     php_info_print_table_row(2, "Snappy Version", SNAPPY_LIB_VERSION);
+#endif
     php_info_print_table_end();
 }
 

--- a/tests/info.phpt
+++ b/tests/info.phpt
@@ -14,5 +14,5 @@ snappy
 
 Snappy support => enabled
 Extension Version => %d.%d.%d
-Snappy Version => %d.%d.%d
+Snappy Version => %s
 %a


### PR DESCRIPTION
Because most downstream distribution don't allow bundled library.

Standard build is unchanged (use the bundled copy)

Notice: I also remove the PHP_INSTALL_HEADERS as this extension doesn't provide any API functions.