### PR TITLE
Add define to be compatible with php-5.2

### DIFF
--- a/php_snappy.h
+++ b/php_snappy.h
@@ -8,6 +8,11 @@
 extern zend_module_entry snappy_module_entry;
 #define phpext_snappy_ptr &snappy_module_entry
 
+/* Support PHP 5.2 */
+#ifndef ZEND_FE_END
+#define ZEND_FE_END {NULL, NULL, NULL}
+#endif
+
 #ifdef PHP_WIN32
 #   define PHP_SNAPPY_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4


### PR DESCRIPTION
Now mod-snappy compatible with php versions from 5.2 to 7.1