### PR TITLE
snappy fails to build as part of PHP source tree fix

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -128,16 +128,6 @@ if test "$PHP_SNAPPY" != "no"; then
   AC_SUBST([SNAPPY_MINOR])
   AC_SUBST([SNAPPY_PATCHLEVEL])
 
-  if test -f "snappy/snappy-stubs-public.h.in"; then
-    if test "$SNAPPY_PATCHLEVEL" -ge 7; then
-      mv snappy/snappy-stubs-public.h.in snappy/snappy-stubs-public.h.in.orig
-      sed 's/${\(HAVE_[[A-Z\_]]*_H_01\)}/@\1@/' snappy/snappy-stubs-public.h.in.orig > snappy/snappy-stubs-public.h.in
-    fi
-  fi
-
-  AC_CONFIG_FILES([snappy/snappy-stubs-public.h])
-  AC_OUTPUT
-
   dnl Check for stdc++
   LIBNAME=stdc++
   AC_MSG_CHECKING([for stdc++])
@@ -164,6 +154,18 @@ if test "$PHP_SNAPPY" != "no"; then
 
   PHP_NEW_EXTENSION(snappy, snappy.c $SNAPPY_SOURCES, $ext_shared)
 
+  if test -f "$ext_srcdir/snappy/snappy-stubs-public.h.in"; then
+    if test "$SNAPPY_PATCHLEVEL" -ge 7; then
+      mv $ext_srcdir/snappy/snappy-stubs-public.h.in \
+      $ext_srcdir/snappy/snappy-stubs-public.h.in.orig
+
+      sed 's/${\(HAVE_[[A-Z\_]]*_H_01\)}/@\1@/' \
+      $ext_srcdir/snappy/snappy-stubs-public.h.in.orig > \
+      $ext_srcdir/snappy/snappy-stubs-public.h.in
+    fi
+  fi
+  AC_CONFIG_FILES([$ext_srcdir/snappy/snappy-stubs-public.h])
+  AC_OUTPUT
   PHP_ADD_BUILD_DIR($ext_builddir/snappy, 1)
   PHP_ADD_INCLUDE([$ext_srcdir/snappy])
   fi


### PR DESCRIPTION
php-ext-snappy would fail to build if you tried to build it into php by doing the following
```
cd php-src/ext
git clone https://github.com/kjdev/php-ext-snappy snappy
cd ../
./buildconf --force
./configure --enable-snappy
```
the configure would fail with the following error
```
config.status: error: cannot find input file: `snappy/snappy-stubs-public.h.in'
```
This pull request fixes this