### PR TITLE
Add PHP 8.5 variants to CI workflow

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -9,6 +9,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.5-alpine'
+          - '8.5-zts-alpine'
           - '8.4-alpine'
           - '8.4-zts-alpine'
           - '8.3-alpine'

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - '8.5'
           - '8.4'
           - '8.3'
           - '8.2'


### PR DESCRIPTION
PHP 8.1 should be phased out in follow-up https://www.php.net/supported-versions.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to support PHP 8.5. Added PHP 8.5 variants for Alpine and thread-safe Alpine configurations on Linux, and included PHP 8.5 in Windows CI environment. Ensures broader compatibility validation across newer PHP versions and multiple platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->